### PR TITLE
Update theme submodule reference to HTTPS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "themes/featherweight"]
 	path = themes/featherweight
-	url = git@github.com:red/web-template.git
+	url = https://github.com/red/web-template.git


### PR DESCRIPTION
This should be what's needed to fix build not being able to pull in the theme submodule. We can try this (referencing this branch if you'd like to test before merging), and then update the other sites.